### PR TITLE
fix(fzf): treat exit code 1 as no matches instead of error

### DIFF
--- a/tests/test_fd_server.py
+++ b/tests/test_fd_server.py
@@ -521,8 +521,9 @@ sys.exit(1)
 
         result = mcp_fd_server.filter_files("nomatch")
 
-        # Should handle empty results gracefully
-        assert "error" in result
+        # Should handle empty results gracefully (fzf exit code 1 = no matches, not error)
+        assert "matches" in result
+        assert result["matches"] == []
 
 
 def test_multiline_support(tmp_path: Path):


### PR DESCRIPTION
## Summary

Fixes fzf error handling to properly treat exit code 1 (no matches found) as an empty result instead of an error.

##  Changes

- Add _handle_fzf_error() helper to centralize error processing
- Return {"matches": []} for no matches vs {"error": "..."} for real errors
- Apply to both multiline and standard filter modes
- Update test expectations